### PR TITLE
[security] Disable sneaky install of bundled themes that core upgrade installs

### DIFF
--- a/includes/disable-bundled-theme-install.php
+++ b/includes/disable-bundled-theme-install.php
@@ -1,0 +1,29 @@
+<?php
+
+function snn_disable_bundled_theme_install() {
+    $options = get_option('snn_security_options');
+    if (isset($options['disable_bundled_theme_install'])) {
+        define('CORE_UPGRADE_SKIP_NEW_BUNDLED', true);
+    }
+}
+add_action('init', 'snn_disable_bundled_theme_install');
+
+function snn_disable_bundled_theme_install_setting_field() {
+    add_settings_field(
+        'disable_bundled_theme_install',
+        __('Disable Bundled Theme Install', 'snn'),
+        'snn_disable_bundled_theme_install_callback',
+        'snn-security',
+        'snn_security_main_section'
+    );
+}
+add_action('admin_init', 'snn_disable_bundled_theme_install_setting_field');
+
+function snn_disable_bundled_theme_install_callback() {
+    $options = get_option('snn_security_options');
+    ?>
+    <input type="checkbox" name="snn_security_options[disable_bundled_theme_install]" value="1" <?php checked(isset($options['disable_bundled_theme_install']), 1); ?>>
+    <p><?php esc_html_e('Enabling this setting will disable bundled theme install when upgrading WordPress.', 'snn'); ?></p>
+    <?php
+}
+?>

--- a/includes/security-page.php
+++ b/includes/security-page.php
@@ -3,12 +3,13 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-require_once SNN_PATH . '/includes/login-math-captcha.php';
-require_once SNN_PATH . '/includes/disable-xmlrpc.php';
-require_once SNN_PATH . '/includes/disable-wp-json-if-not-logged-in.php';
-require_once SNN_PATH . '/includes/disable-file-editing.php';
-require_once SNN_PATH . '/includes/remove-rss.php';
-require_once SNN_PATH . '/includes/remove-wp-version.php';
+require_once SNN_PATH . 'includes/login-math-captcha.php';
+require_once SNN_PATH . 'includes/disable-xmlrpc.php';
+require_once SNN_PATH . 'includes/disable-wp-json-if-not-logged-in.php';
+require_once SNN_PATH . 'includes/disable-file-editing.php';
+require_once SNN_PATH . 'includes/remove-rss.php';
+require_once SNN_PATH . 'includes/remove-wp-version.php';
+require_once SNN_PATH . 'includes/disable-bundled-theme-install.php';
 
 function snn_add_security_submenu() {
     add_submenu_page(


### PR DESCRIPTION
By default WordPress installs the latest and "greatest" Twenty Twenty Whatever theme when performing major(?) core upgrades. That's a major security flaw, considering that each installed theme increases the attack vector.

Just add to delete that crap from a bunch of my sites.